### PR TITLE
Update typeahead.js-bootstrap.css

### DIFF
--- a/web-app/css/typeahead.js-bootstrap.css
+++ b/web-app/css/typeahead.js-bootstrap.css
@@ -1,6 +1,4 @@
 /* ignore this line */
-.container { margin:30px; }
-
 .twitter-typeahead {
     width: 100%;
     position: relative;


### PR DESCRIPTION
Removed container margin styling, as this modifies bootstrap's standard behaviour.
